### PR TITLE
disasm: Add armbe support

### DIFF
--- a/disasm.cpp
+++ b/disasm.cpp
@@ -99,6 +99,11 @@ const char *disassemble(const char *_arch_mode, const char *codehex, uint64_t st
 		mode = CS_MODE_ARM;
 	}
 
+	if (arch_mode=="armbe") {
+		arch = CS_ARCH_ARM;
+		mode = (cs_mode)(CS_MODE_ARM|CS_MODE_BIG_ENDIAN);
+	}
+
 	if (arch_mode=="arm64") {
 		arch = CS_ARCH_ARM64;
 		mode = CS_MODE_ARM;

--- a/disasm.js
+++ b/disasm.js
@@ -87,6 +87,7 @@ function toHex(c) {
     'x86_32': 'x86 32bit',
     'x86_64': 'x86 64bit',
     "arm": "ARM - little endian",
+    "armbe": "ARM - big endian",
     "thumb": "THUMB - little endian",
     "thumbbe": "THUMB - big endian",
     "arm64": "ARM64",


### PR DESCRIPTION
Hi, I found this assembler/disassembler in the live version at <https://disasm.x32.dev/>. I found it pretty useful, but it would be even more useful with ARM big endian support, because big endian is easier to type sometimes (especially when you have the instruction formatted as a single 32-bit integer).

This PR attempts to add armbe support, but I haven't tested it because I don't have an emscripten toolchain installed.